### PR TITLE
Encode share links as gzip and keep decoding legacy hashes

### DIFF
--- a/src/web/app.vue
+++ b/src/web/app.vue
@@ -14,15 +14,15 @@ const getCanvasStyle = (mode: ViewMode) => {
   return { display: isMode(mode) ? 'block' : 'none' };
 }
 
-const importDataFromHash = () => {
+const importDataFromHash = async () => {
   const hash = window.location.hash.slice(1);
   if (hash) {
-    configStore.importConfigBase64(hash);
+    await configStore.importConfigBase64(hash);
   }
 }
 
-onMounted(() => {
-  importDataFromHash();
+onMounted(async () => {
+  await importDataFromHash();
   restart();
 });
 

--- a/src/web/components/config-editor/components/sections/link-section.vue
+++ b/src/web/components/config-editor/components/sections/link-section.vue
@@ -6,25 +6,26 @@ import { useConfigStore } from "@/web/store/config";
 
 const configStore = useConfigStore();
 
-const getShareLink = () => {
-  return `${location.origin}${location.pathname}#${configStore.exportConfigBase64()}`;
+const getShareLink = async () => {
+  return `${location.origin}${location.pathname}#${await configStore.exportConfigBase64()}`;
 }
 
-const copyShareLink = () => {
-  navigator.clipboard.writeText(getShareLink());
+const copyShareLink = async () => {
+  await navigator.clipboard.writeText(await getShareLink());
 }
 
 const DEFAULT_TITLE = "Copy configuration share link";
 const TEMP_TITLE = "[ COPIED ] Click another time to shorten!";
 const title = ref(DEFAULT_TITLE);
 
-const onClick = () => {
+const onClick = async () => {
   if (title.value === TEMP_TITLE) {
-    window.open(`https://linker.smoren.me/#${getShareLink()}`, '_blank')?.focus();
+    const link = await getShareLink();
+    window.open(`https://linker.smoren.me/#${encodeURIComponent(link)}`, '_blank')?.focus();
     return;
   }
 
-  copyShareLink();
+  await copyShareLink();
   title.value = TEMP_TITLE;
   setTimeout(() => {
     title.value = DEFAULT_TITLE;

--- a/src/web/store/config.ts
+++ b/src/web/store/config.ts
@@ -28,6 +28,7 @@ import {
   convertWorldConfigForBackwardCompatibility,
   convertTypesSymmetricConfigForBackwardCompatibility,
 } from '@/web/utils/backward';
+import { decodeSharePayload, encodeSharePayload } from '@/web/utils/share-codec';
 import type { ShowConfig } from "@/lib/drawer/types";
 import { createDefaultShowConfig } from "@/lib/drawer/2d";
 
@@ -138,8 +139,8 @@ export const useConfigStore = defineStore("config", () => {
     };
   }
 
-  const exportConfigBase64 = () => {
-    return btoa(JSON.stringify(exportConfig()));
+  const exportConfigBase64 = async () => {
+    return encodeSharePayload(JSON.stringify(exportConfig()));
   }
 
   const importConfig = (config: {
@@ -171,17 +172,18 @@ export const useConfigStore = defineStore("config", () => {
     }
   }
 
-  const importConfigBase64 = (config: string) => {
+  const importConfigBase64 = async (config: string) => {
     try {
-      const newConfig = JSON.parse(atob(config)) as {
+      const json = await decodeSharePayload(config);
+      const newConfig = JSON.parse(json) as {
         worldConfig?: WorldConfig,
         typesConfig?: TypesConfig,
-        typeSymmetricConfig?: TypesSymmetricConfig,
+        typesSymmetricConfig?: TypesSymmetricConfig,
       };
 
       importConfig(newConfig);
     } catch (e) {
-      console.warn(e);
+      console.warn('Share link is invalid or truncated', e);
     }
   }
 

--- a/src/web/utils/share-codec.ts
+++ b/src/web/utils/share-codec.ts
@@ -1,0 +1,55 @@
+const GZIP_PREFIX = 'g1.';
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let bin = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlToBytes(b64: string): Uint8Array {
+  const pad = '='.repeat((4 - (b64.length % 4)) % 4);
+  const normalized = (b64 + pad).replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(normalized);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    out[i] = bin.charCodeAt(i);
+  }
+  return out;
+}
+
+export async function encodeSharePayload(json: string): Promise<string> {
+  if (typeof CompressionStream === 'undefined') {
+    return bytesToBase64Url(new TextEncoder().encode(json));
+  }
+  const stream = new Blob([new TextEncoder().encode(json)])
+    .stream()
+    .pipeThrough(new CompressionStream('gzip'));
+  const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+  return GZIP_PREFIX + bytesToBase64Url(bytes);
+}
+
+export async function decodeSharePayload(raw: string): Promise<string> {
+  let input = raw;
+  try {
+    input = decodeURIComponent(raw);
+  } catch {
+  }
+
+  if (input.startsWith(GZIP_PREFIX)) {
+    if (typeof DecompressionStream === 'undefined') {
+      throw new Error('Gzip share links need a modern browser');
+    }
+    const bytes = base64UrlToBytes(input.slice(GZIP_PREFIX.length));
+    const stream = new Blob([bytes])
+      .stream()
+      .pipeThrough(new DecompressionStream('gzip'));
+    return await new Response(stream).text();
+  }
+
+  const pad = '='.repeat((4 - (input.length % 4)) % 4);
+  const normalized = (input + pad).replace(/-/g, '+').replace(/_/g, '/');
+  return atob(normalized);
+}

--- a/tests/share/share-codec.test.ts
+++ b/tests/share/share-codec.test.ts
@@ -1,0 +1,37 @@
+import { gzipSync } from 'zlib';
+import { describe, expect, it } from '@jest/globals';
+import { decodeSharePayload, encodeSharePayload } from '../../src/web/utils/share-codec';
+
+const PAYLOAD = '{"worldConfig":{"PHYSIC_MODEL":"v2"},"typesConfig":{"TYPE_LINKS":[1,2]}}';
+
+function toBase64Url(buffer: Buffer): string {
+  return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+describe('share codec', () => {
+  it('decodes legacy btoa JSON hashes', async () => {
+    const hash = Buffer.from(PAYLOAD, 'utf8').toString('base64');
+    expect(await decodeSharePayload(hash)).toBe(PAYLOAD);
+  });
+
+  it('decodes url-safe legacy hashes', async () => {
+    const hash = toBase64Url(Buffer.from(PAYLOAD, 'utf8'));
+    expect(await decodeSharePayload(hash)).toBe(PAYLOAD);
+  });
+
+  it('decodes g1.gzip hashes', async () => {
+    const hash = `g1.${toBase64Url(gzipSync(PAYLOAD))}`;
+    expect(await decodeSharePayload(hash)).toBe(PAYLOAD);
+  });
+
+  it('encodes a gzip hash that roundtrips', async () => {
+    const encoded = await encodeSharePayload(PAYLOAD);
+    expect(encoded.startsWith('g1.')).toBe(true);
+    expect(await decodeSharePayload(encoded)).toBe(PAYLOAD);
+  });
+
+  it('decodes percent-encoded hashes', async () => {
+    const hash = `g1.${toBase64Url(gzipSync(PAYLOAD))}`;
+    expect(await decodeSharePayload(encodeURIComponent(hash))).toBe(PAYLOAD);
+  });
+});


### PR DESCRIPTION
## Что меняется
- Новые share-ссылки пишутся как `g1.` + gzip + base64url, конфиг лучше влезает в URL.
- Старые hash вида `btoa(JSON)` по-прежнему открываются.

## Зачем
- Далее будем раздувать конфиг, столкнёмся с ограничениями на длину share-ссылки. PR поможет этого избежать